### PR TITLE
74 repo articles cookbook cheat sheet updates

### DIFF
--- a/SDPi_Supplement/SDPi_Supplement.iml
+++ b/SDPi_Supplement/SDPi_Supplement.iml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/asciidoc-converter/src/main/kotlin" isTestSource="false" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/SDPi_Supplement/articles/sdpi-article-asciidoc-cheat-sheet.adoc
+++ b/SDPi_Supplement/articles/sdpi-article-asciidoc-cheat-sheet.adoc
@@ -5,7 +5,7 @@
 :toc-title: Contents
 :toc: left
 :toclevels: 3
-:sectnums:
+:!sectnums:
 :icons: font
 :imagesoutdir: images/
 :imagesdir: images/
@@ -13,55 +13,53 @@
 WARNING: This is a straw-man article. Content hackers welcomed!  *_Add issues to the <<Parking Lot Stuff>> section._*
 
 == 'Sup with this "Cheat Sheet"?
-Though the article https://github.com/IHE/sdpi-fhir/wiki/IHE-TF-SDPi-Content-in-AsciiDoc[_IHE Technical Framework / SDPi Content in AsciiDoc_] covers AsciiDoc application to specific content needs of the SDPi supplement, for those who are just getting started with the language, figuring out where the basics (and advanced) usage is documented is ... challenging.
+This article provides general AsciiDoc specification information and links to the specification documentation.  It focuses on those elements that are actively used in the IHE TF / SDPi specification (as opposed to the entirety of the AsciiDoc language). For those who are just getting started with the language, figuring out where the basics (and advanced) usage is documented is ... challenging.
 
-This quick reference guide helps cover that space between the content conventions and the actual AsciiDoc language.  For more detailed information on the AsciiDoc use conventions, see the article https://github.com/IHE/sdpi-fhir/blob/50ace3692b9299cdfcea434501df87b192f5220c/SDPi_Supplement/articles/sdpi-article-ihe-tf-asciidoc-cookbook.adoc[IHE TF / SDPi AsciiDoc Cookbook].
+For more detailed information on the AsciiDoc use conventions in the SDPi supplement, see the article https://github.com/IHE/sdpi-fhir/blob/50ace3692b9299cdfcea434501df87b192f5220c/SDPi_Supplement/articles/sdpi-article-ihe-tf-asciidoc-cookbook.adoc[IHE TF / SDPi AsciiDoc Cookbook].
 
 The document links are generally to https://docs.asciidoctor.org/asciidoc/latest/[_Asciidoctor Docs online documentation_].
 
 == Document Stuff
 Add:  Process basics:  AsciiDoc source => AsciiDoctor processor => convert to published format (HTML)
 Add:  Line oriented / stacks of blocks (starting with block=line)
+Add:  Attributes :attribute: value  pairs
+ADD:  Document types and "header" blocks
 
 == Blocks Stuff
 ADD:  Basic blocks references
-ADD:  References for types of blocks
-ADD:
+ADD:  Block roles
+ADD:  Block "types" and delimiters
+ADD:  Comment / non-processed blocks
+
+=== Empty Lines
+ADD:  Empty Lines both "+" endings & "{empty} +  "
 
 == Reference Stuff
 Add:  [#xuze, reftext=YIKES]
-Add:  :attribute: value  pairs
 Add:  macro::name()  ... e.g., image::AFCisGreat.png(...)
+ADD:  Anchors
 
 == Text Formatting Stuff
 
+ADD:  Basic formatting - limitations!!!
 ADD:  Admonitions
 ADD:  So you want to indent do you ... good luck!
 
 == Table Stuff
 ADD:  Basic table references
 ADD:  Table formatting examples (alignment, spanning, ...)
+ADD:  https://docs.asciidoctor.org/asciidoc/latest/tables/data-format/#data-table-formats[Tables from Files (CSV, TSV, DSV)]
+
+== Metadata in AsciiDoc
+ADD:  general contstructs (from above) that can be used for UML Metadata (non displayed content) in AsciiDoc
+ADD:  Link to the cookbook article that talks specifically about TF UML metadata (e.g., for requirements interoperability)
 
 == Parking Lot Stuff
 
 (in no particular #order#)
 
-* admonitions
-
-* indenting
-
-* empty lines
-
-* Table Formatting
-
-* attributes
-
-* references
-
-* anchors
-
-* https://docs.asciidoctor.org/asciidoc/latest/tables/data-format/#data-table-formats[Tables from Files (CSV, TSV, DSV)]
-
-*  ...
+. Add new items below this line ...
+. ...
+. ...
 
 

--- a/SDPi_Supplement/articles/sdpi-article-ihe-tf-asciidoc-cookbook.adoc
+++ b/SDPi_Supplement/articles/sdpi-article-ihe-tf-asciidoc-cookbook.adoc
@@ -4,13 +4,13 @@
 :xrefstyle: short
 :toc-title: Contents
 :toc: left
-:toclevels: 2
+:toclevels: 3
 :!sectnums:
 :icons: font
 :imagesoutdir: images/
 :imagesdir: images/
 
-WARNING: This is a straw-man article. Content hackers welcomed!  Add content requests to section <<Topics Parking Lot>>.
+WARNING: This is a straw-man article - actively under development!  Add content requests to section <<Topics Parking Lot>>.
 
 == Cookbook Overview
 This article provides a *_handy_* reference place for the conventions and templates that editors will apply in creating content for the SDPi specification.  It is organized so as to help with specific editorial tasks (e.g., references, images, tables, metadata, etc.).
@@ -21,19 +21,40 @@ Related articles that support the information below include:
 * https://github.com/IHE/sdpi-fhir/wiki/SDPi-File-Organization-Scheme[SDPi File Organization Scheme]
 
 == Document Conventions
-ADD:  Copy and past document header
-ADD:  Unique attributes or other directives used
-ADD:  Multi-File / Multi-Doc Support conventions
+The items in this section apply to either the document overall or to entire files.
 
-== IHE TF Elements Conventions
+=== HTML -- Continuous Build
+In order to support a "continuous build" process -- namely, being able to frequently render to HTML and ensure that the process is working -- the steps below should be followed.
 
-==
+NOTE:  This See the general tooling configuration article on the wiki for more information:  https://github.com/IHE/sdpi-fhir/wiki/Crafting-AsciiDoc-based-SDPi-Supplement-Content#authoring-using-intellij-platform[Authoring Using IntelliJ Platform]
 
-== #FROM ORIGINAL ASCIIDOC/README.MD#
+==== IntelliJ Configuration & Processes
+
+ROUGH NOTES FROM DEMO SESSION 2022.09.14 ...
+
+. (Optional) set up SDPi_Supplement + asciidoc-conerter as IntelliJ Projects - to make work in those directories easier
+... <select directory ... File::New::Project From Existing Sources ..
+. Ensure Gradle is installed!
+.
+
+==== Publishing the SDPi Supplement to HTML
+ADD:  How to run the converter to see the actual published supplement
+
+=== Multi-File / Multi-Doc Support
+ADD:  General discussion and conventions and support for the AsciiDoc multi-file approach
+ADD:  Tooling used + configuration
+
+=== Document Header
+ADD:  Template for what should be at the top of each of the .adoc files
+
+=== Attributes (Document Level) for SDPi
+ADD:  Specific attributes (document level) that should be included / considered for each .adoc file
+
+== AsciiDoc Content Conventions
 
 The following subsections specify conventions for the writing of Asciidoc markup.
-It makes use of [Backus-Naur forms](https://en.wikipedia.org/wiki/Backus%E2%80%93Naur_form), which may include
-[Regular expressions](https://en.wikipedia.org/wiki/Regular_expression) (signified by enclosing slashes) to describe
+It makes use of https://en.wikipedia.org/wiki/Backus%E2%80%93Naur_form[Backus-Naur forms], which may include
+https://en.wikipedia.org/wiki/Regular_expression[Regular expressions] (signified by enclosing slashes) to describe
 grammars for acceptable characters of symbols.
 
 === Identifier naming
@@ -143,6 +164,30 @@ include::../plantuml/vol2-figure-xyz.puml[]
 ....
 ----
 ====
+
+== IHE TF Elements Conventions
+The SDPi supplement conforms to the IHE Technical Framework (TF) elements and template.  A general UML model of the TF is provided in the sections below, along with how that model, including element metadata and relationships, is capured in AsciiDoc content.
+
+===  IHE TF General Model
+ADD: Basic UML model of IHE TF elements that will then be reflected (sooner or later) in the supplement
+
+== Requirements Interoperability Support
+In order to achieve "requirements Interoperability" -- where each requirement is matched with the one or more capabilities for its fulfilment -- each requirement should be marked with appropriate metadata + linkages to one or more capabilities.  The following sections provide AsciiDoc
+
+=== RI General Model
+ADD:  UML Requirements Interoperability Model
+ADD:  Example of how the metadata is recorded
+
+=== Requirement Definition
+ADD: specification and examples for requirements - including, requirement types and metadata
+ADD: specification of URI for requirements ... naming conventions
+
+=== Requirement-to-Capability Linkage
+ADD:  specification of how to link a requirement to one or more capabilities (that fulfil the requirement)
+
+=== Requirement Traceability & Coverage
+ADD:  Description on how RI might be used to determine coverage (including percentage?) and traceability
+
 
 == Topics Parking Lot
 

--- a/SDPi_Supplement/articles/sdpi-article-ihe-tf-asciidoc-cookbook.adoc
+++ b/SDPi_Supplement/articles/sdpi-article-ihe-tf-asciidoc-cookbook.adoc
@@ -38,11 +38,27 @@ ROUGH NOTES FROM DEMO SESSION 2022.09.14 ...
 . Ensure Gradle is installed!
 .. IntelliJ should discover the build.gradle.kts script file in the converter project root director; this file contains instructions for how to build the application
 .. Gradel should be automatically installed and configured for the asciidoc-converter project
-.Open asciidoc converter project
-. ...
+. Open asciidoc converter project
+..  1st time the converter project is opened ...
+..  Configure the application's "run" command line arguments
+... Select the "Run/Debug Configuration" item above the file display area (between the hammer and the play icons)
+... Select "Edit Configurations ..."
+... In the "Run" item window, past the following:
+
+.AsciiDoc-Converter Command Line
+====
+[source,asciidoc]
+----
+run --args="--input-file ../asciidoc/sdpi-supplement.adoc --output-folder ../sdpi-supplement"
+----
+====
+
+... Select "Apply" or "OK" and you should be good to go!
 . From Gradle window (on right side)
-... Navigate to  Tasks::applcation::run
-... Execute (double click on) "run"
+... Press the Play icon at the top of the project window OR
+... Navigate to  Tasks::application::run & Execute (double click on "run")
+... A "Run" log window will display at the bottom of the screen showing the execution steps of the project
+... You should see "BUILD SUCCESSFUL" as one of the last entries in the log window
 )
 
 ==== Publishing the SDPi Supplement to HTML

--- a/SDPi_Supplement/articles/sdpi-article-ihe-tf-asciidoc-cookbook.adoc
+++ b/SDPi_Supplement/articles/sdpi-article-ihe-tf-asciidoc-cookbook.adoc
@@ -4,10 +4,7 @@
 :xrefstyle: short
 :toc-title: Contents
 :toc: left
-<<<<<<< HEAD
 :toclevels: 3
-=======
-:toclevels: 2
 :!sectnums:
 :icons: font
 :imagesoutdir: images/

--- a/SDPi_Supplement/articles/sdpi-article-ihe-tf-asciidoc-cookbook.adoc
+++ b/SDPi_Supplement/articles/sdpi-article-ihe-tf-asciidoc-cookbook.adoc
@@ -8,17 +8,13 @@
 :toclevels: 3
 =======
 :toclevels: 2
->>>>>>> 696f5c10d3bfea5018f9c64464d27e9f148580b5
 :!sectnums:
 :icons: font
 :imagesoutdir: images/
 :imagesdir: images/
 
-<<<<<<< HEAD
 WARNING: This is a straw-man article - actively under development!  Add content requests to section <<Topics Parking Lot>>.
-=======
-WARNING: This is a straw-man article. Content hackers welcomed!  Add content requests to section <<Topics Parking Lot>>.
->>>>>>> 696f5c10d3bfea5018f9c64464d27e9f148580b5
+
 
 == Cookbook Overview
 This article provides a *_handy_* reference place for the conventions and templates that editors will apply in creating content for the SDPi specification.  It is organized so as to help with specific editorial tasks (e.g., references, images, tables, metadata, etc.).
@@ -29,19 +25,7 @@ Related articles that support the information below include:
 * https://github.com/IHE/sdpi-fhir/wiki/SDPi-File-Organization-Scheme[SDPi File Organization Scheme]
 
 == Document Conventions
-<<<<<<< HEAD
 The items in this section apply to either the document overall or to entire files.
-=======
-ADD:  Copy and past document header
-ADD:  Unique attributes or other directives used
-ADD:  Multi-File / Multi-Doc Support conventions
-
-== IHE TF Elements Conventions
-
-==
-
-== #FROM ORIGINAL ASCIIDOC/README.MD#
->>>>>>> 696f5c10d3bfea5018f9c64464d27e9f148580b5
 
 === HTML -- Continuous Build
 In order to support a "continuous build" process -- namely, being able to frequently render to HTML and ensure that the process is working -- the steps below should be followed.
@@ -186,7 +170,7 @@ include::../plantuml/vol2-figure-xyz.puml[]
 ====
 
 == IHE TF Elements Conventions
-The SDPi supplement conforms to the IHE Technical Framework (TF) elements and template.  A general UML model of the TF is provided in the sections below, along with how that model, including element metadata and relationships, is capured in AsciiDoc content.
+The SDPi supplement conforms to the IHE Technical Framework (TF) elements and template.  A general UML model of the TF is provided in the sections below, along with how that model, including element metadata and relationships, is captured in AsciiDoc content.
 
 ===  IHE TF General Model
 ADD: Basic UML model of IHE TF elements that will then be reflected (sooner or later) in the supplement

--- a/SDPi_Supplement/articles/sdpi-article-ihe-tf-asciidoc-cookbook.adoc
+++ b/SDPi_Supplement/articles/sdpi-article-ihe-tf-asciidoc-cookbook.adoc
@@ -36,7 +36,14 @@ ROUGH NOTES FROM DEMO SESSION 2022.09.14 ...
 . (Optional) set up SDPi_Supplement + asciidoc-conerter as IntelliJ Projects - to make work in those directories easier
 ... <select directory ... File::New::Project From Existing Sources ..
 . Ensure Gradle is installed!
-.
+.. IntelliJ should discover the build.gradle.kts script file in the converter project root director; this file contains instructions for how to build the application
+.. Gradel should be automatically installed and configured for the asciidoc-converter project
+.Open asciidoc converter project
+. ...
+. From Gradle window (on right side)
+... Navigate to  Tasks::applcation::run
+... Execute (double click on) "run"
+)
 
 ==== Publishing the SDPi Supplement to HTML
 ADD:  How to run the converter to see the actual published supplement

--- a/SDPi_Supplement/articles/sdpi-article-ihe-tf-asciidoc-cookbook.adoc
+++ b/SDPi_Supplement/articles/sdpi-article-ihe-tf-asciidoc-cookbook.adoc
@@ -5,12 +5,12 @@
 :toc-title: Contents
 :toc: left
 :toclevels: 2
-:sectnums:
+:!sectnums:
 :icons: font
 :imagesoutdir: images/
 :imagesdir: images/
 
-WARNING: This is a straw-man article. Content hackers welcomed!  Add content requests to section <<Topics Parking Lot>> below.
+WARNING: This is a straw-man article. Content hackers welcomed!  Add content requests to section <<Topics Parking Lot>>.
 
 == Cookbook Overview
 This article provides a *_handy_* reference place for the conventions and templates that editors will apply in creating content for the SDPi specification.  It is organized so as to help with specific editorial tasks (e.g., references, images, tables, metadata, etc.).
@@ -20,7 +20,16 @@ Related articles that support the information below include:
 * https://github.com/IHE/sdpi-fhir/blob/50ace3692b9299cdfcea434501df87b192f5220c/SDPi_Supplement/articles/sdpi-article-asciidoc-cheat-sheet.adoc[AsciiDoc Cheat Sheet]
 * https://github.com/IHE/sdpi-fhir/wiki/SDPi-File-Organization-Scheme[SDPi File Organization Scheme]
 
-== Asciidoc Source Conventions
+== Document Conventions
+ADD:  Copy and past document header
+ADD:  Unique attributes or other directives used
+ADD:  Multi-File / Multi-Doc Support conventions
+
+== IHE TF Elements Conventions
+
+==
+
+== #FROM ORIGINAL ASCIIDOC/README.MD#
 
 The following subsections specify conventions for the writing of Asciidoc markup.
 It makes use of [Backus-Naur forms](https://en.wikipedia.org/wiki/Backus%E2%80%93Naur_form), which may include


### PR DESCRIPTION
Article updates, including:

1. Sync with David's updates & general article organization
2. Added early section for the asciidoc converter application - configuration & execution 

NOTE:  The article still has a numbered outline issue when the run time arguments line is inserted.  No time to determine how to fix.  

