### PR TITLE
Added LocalTimeDate to Title Page

### DIFF
--- a/SDPi_Supplement/asciidoc/sdpi-supplement.adoc
+++ b/SDPi_Supplement/asciidoc/sdpi-supplement.adoc
@@ -12,7 +12,7 @@
 :docinfo: shared
 
 :ihe_supplement_sdpi_revision: 1.0.2
-:ihe_supplement_sdpi_revision_date: 26 January 2023
+:ihe_supplement_sdpi_revision_date: {localdatetime}
 :ihe_supplement_sdpi_revision_label: Draft in Preparation for Public Comment
 
 {empty} +


### PR DESCRIPTION
Updated the "Date:" field to use the localTimeDate intrinsic document attribute.

@d-gregorczyk :  Note that the full time-date with time zone offset was used.  There is some formatting available + to use UTC only etc.  But for the purposes of this version of the supplement ... this should be sufficient.
