### PR TITLE
#338 Use wbr tag to create virtual newline positions.

### DIFF
--- a/SDPi_Supplement/articles/sdpi-article-ihe-tf-asciidoc-cookbook.adoc
+++ b/SDPi_Supplement/articles/sdpi-article-ihe-tf-asciidoc-cookbook.adoc
@@ -10,7 +10,7 @@
 :imagesoutdir: images/
 :imagesdir: images/
 
-WARNING: This is a straw-man article. Content hackers welcomed!  Add content requests to section <<Topics Parking Lot>> below.
+WARNING: This is a straw-man article. Content hackers welcomed!  Add content requests to section ++<<Topics Parking Lot>>++ below.
 
 == Cookbook Overview
 This article provides a *_handy_* reference place for the conventions and templates that editors will apply in creating content for the SDPi specification.  It is organized so as to help with specific editorial tasks (e.g., references, images, tables, metadata, etc.).

--- a/SDPi_Supplement/asciidoc/volume2/gateways/tf2-ch-b-gateway-acm.adoc
+++ b/SDPi_Supplement/asciidoc/volume2/gateways/tf2-ch-b-gateway-acm.adoc
@@ -267,9 +267,7 @@ If a private *<<acronym_mdc>>* code is used for the coding of the SDC device-rel
 
 |OBX-3
 |Observation Identifier
-|pm:Mds or pm:Vmd or pm:Channel
-/pm:Type
-/@Code
+|pm:Mds or pm:Vmd or pm:Channel+++<wbr/>+++/pm:Type+++<wbr/>+++/@Code
 |Please refer to <<ref_acm_obs_id_mapping>> for further information.
 
 |OBX-4
@@ -367,7 +365,7 @@ NOTE: The HL7 date & time format differs from the xsd date/time formats and requ
 |IHE ACM Alert Event Phase |SDC Alert Condition/Signal State
 
 |start
-|*pm:AlertConditionState /pm:DeterminationTime* which shall represent the alert onset date/time.
+|*pm:AlertConditionState+++<wbr/>+++/pm:DeterminationTime* which shall represent the alert onset date/time.
 
 |continue
 |The gateway may resend the unchanged alert event information, for example, on a regular basis in order to mitigate the risk of an alert message loss, or after a reconnection to the Alert Manager or Alert Consumer in order to synchronize the current alert status. In this case, the date/time is determined by the gateway for this message.
@@ -375,29 +373,29 @@ NOTE: The HL7 date & time format differs from the xsd date/time formats and requ
 
 
 |end
-|*pm:AlertConditionState /pm:DeterminationTime* which shall represent the end of the alert condition without latching.
+|*pm:AlertConditionState+++<wbr/>+++/pm:DeterminationTime* which shall represent the end of the alert condition without latching.
 
 |update
-|*pm:AlertConditionState /pm:DeterminationTime* or *pm:AlertSignalState /pm:DeterminationTime* for any updates/changes to be reported but does not match any other Alert Event Phase mapping criteria.
+|*pm:AlertConditionState+++<wbr/>+++/pm:DeterminationTime* or *pm:AlertSignalState+++<wbr/>+++/pm:DeterminationTime* for any updates/changes to be reported but does not match any other Alert Event Phase mapping criteria.
 
-Note that the *pm:AlertConditionState /pm:DeterminationTime* changes only when the *@Presence* attribute is updated. The gateway has to determine the date/time by itself when other attributes have changed (e.g. alert priority).
+Note that the *pm:AlertConditionState+++<wbr/>+++/pm:DeterminationTime* changes only when the *@Presence* attribute is updated. The gateway has to determine the date/time by itself when other attributes have changed (e.g. alert priority).
 
 |escalate
-|*pm:AlertConditionState /pm:DeterminationTime* which shall represent the change of the alert priority.
+|*pm:AlertConditionState+++<wbr/>+++/pm:DeterminationTime* which shall represent the change of the alert priority.
 
 Note that when there are more changes than just the Alert Priority, the Alert Event Phase shall be reported as *"update"*.
 
-Note that the *pm:AlertConditionState /pm:DeterminationTime* changes only when the *@Presence* attribute is updated. The gateway has to determine the date/time by itself when other attributes have changed (e.g. alert priority).
+Note that the *pm:AlertConditionState+++<wbr/>+++/pm:DeterminationTime* changes only when the *@Presence* attribute is updated. The gateway has to determine the date/time by itself when other attributes have changed (e.g. alert priority).
 
 |deescalate
-|*pm:AlertConditionState /pm:DeterminationTime* which shall represent the change of the alert priority.
+|*pm:AlertConditionState+++<wbr/>+++/pm:DeterminationTime* which shall represent the change of the alert priority.
 
 Note that when there are more changes than just the Alert Priority, the Alert Event Phase shall be reported as *"update"*.
 
-Note that the *pm:AlertConditionState /pm:DeterminationTime* changes only when the *@Presence* attribute is updated. The gateway has to determine the date/time by itself when other attributes have changed (e.g. alert priority).
+Note that the *pm:AlertConditionState+++<wbr/>+++/pm:DeterminationTime* changes only when the *@Presence* attribute is updated. The gateway has to determine the date/time by itself when other attributes have changed (e.g. alert priority).
 
 |reset
-|*pm:AlertSignalState /pm:DeterminationTime* which shall represent the end of a latched alert event state.
+|*pm:AlertSignalState+++<wbr/>+++/pm:DeterminationTime* which shall represent the end of a latched alert event state.
 
 |===
 
@@ -429,23 +427,21 @@ If a private *<<acronym_mdc>>* code is used for the coding of the SDC coded elem
 
 |OBX-3/CWE-1
 |Identifier
-|pm:AlertConditionDescriptor
-/pm:Type
-/@Code
+|pm:AlertConditionDescriptor+++<wbr/>+++/pm:Type+++<wbr/>+++/@Code
 |
 
 |OBX-3/CWE-2
 |Text
 |If *@Code* is an <<acronym_mdc>> code, this field shall contain the RefId of the <<acronym_mdc>> code.
 
-In all other cases, the field shall be set to the pm:AlertConditionDescriptor /pm:Type /@SymbolicCodeName.
+In all other cases, the field shall be set to the pm:AlertConditionDescriptor+++<wbr/>+++/pm:Type+++<wbr/>+++/@SymbolicCodeName.
 | Note that <<acronym_mdc>> is the default coding system if no coding system is specified.
 
 |OBX-3/CWE-3
 |Name of Coding System
 |*"<<acronym_mdc>>"* if no other coding system is specified.
 
-In all other cases, the field shall be set to pm:AlertConditionDescriptor /pm:Type /@CodingSystem.
+In all other cases, the field shall be set to pm:AlertConditionDescriptor+++<wbr/>+++/pm:Type+++<wbr/>+++/@CodingSystem.
 
 |Note that <<acronym_mdc>> is the default coding system if no coding system is specified.
 
@@ -457,9 +453,7 @@ Please refer to <<ref_acm_containment_tree_mapping>> for further information.
 
 |OBX-5
 |Observation Value
-|pm:AlertConditionDescriptor
-/pm:Type
-/pm:ConceptDescription
+|pm:AlertConditionDescriptor+++<wbr/>+++/pm:Type+++<wbr/>+++/pm:ConceptDescription
 |
 
 |OBX-11
@@ -539,8 +533,7 @@ Please refer to <<ref_acm_containment_tree_mapping>> for further information.
 
 |OBX-5/CWE-1
 |Identifier
-|pm:AlertConditionDescriptor
-/pm:Type
+|pm:AlertConditionDescriptor+++<wbr/>+++/pm:Type
 /@Code
 |
 
@@ -548,21 +541,20 @@ Please refer to <<ref_acm_containment_tree_mapping>> for further information.
 |Text
 |If *@Code* is an <<acronym_mdc>> code, this field shall contain the RefId of the <<acronym_mdc>> code.
 
-In all other cases, the field shall be set to the pm:AlertConditionDescriptor /pm:Type /@SymbolicCodeName.
+In all other cases, the field shall be set to the pm:AlertConditionDescriptor+++<wbr/>+++/pm:Type+++<wbr/>+++/@SymbolicCodeName.
 | Note that <<acronym_mdc>> is the default coding system if no coding system is specified.
 
 |OBX-5/CWE-3
 |Name of Coding System
 |*"<<acronym_mdc>>"* if no other coding system is specified.
 
-In all other cases, the field shall be set to pm:AlertConditionDescriptor /pm:Type /@CodingSystem.
+In all other cases, the field shall be set to pm:AlertConditionDescriptor+++<wbr/>+++/pm:Type+++<wbr/>+++/@CodingSystem.
 
 |Note that <<acronym_mdc>> is the default coding system if no coding system is specified.
 
 |OBX-5/CWE-9
 |Original Text
-|pm:AlertConditionDescriptor
-/pm:Type
+|pm:AlertConditionDescriptor+++<wbr/>+++/pm:Type
 /pm:ConceptDescription
 |
 
@@ -700,14 +692,14 @@ Please refer to <<ref_acm_containment_tree_mapping>> for further information.
 |Text
 |If *@Code* is an <<acronym_mdc>> code, this field shall contain the RefId of the <<acronym_mdc>> code.
 
-In all other cases, the field shall be set to the pm:Mds or pm:Vmd or pm:Channel or pm:Metric /pm:Type /@SymbolicCodeName.
+In all other cases, the field shall be set to the pm:Mds or pm:Vmd or pm:Channel or pm:Metric+++<wbr/>+++/pm:Type+++<wbr/>+++/@SymbolicCodeName.
 | Note that <<acronym_mdc>> is the default coding system if no coding system is specified.
 
 |OBX-5/CWE-3
 |Name of Coding System
 |*"<<acronym_mdc>>"* if no other coding system is specified.
 
-In all other cases, the field shall be set to pm:Mds or pm:Vmd or pm:Channel or pm:Metric /pm:Type /@CodingSystem.
+In all other cases, the field shall be set to pm:Mds or pm:Vmd or pm:Channel or pm:Metric+++<wbr/>+++/pm:Type+++<wbr/>+++/@CodingSystem.
 
 |Note that <<acronym_mdc>> is the default coding system if no coding system is specified.
 

--- a/SDPi_Supplement/asciidoc/volume2/gateways/tf2-ch-b-gateway-dec.adoc
+++ b/SDPi_Supplement/asciidoc/volume2/gateways/tf2-ch-b-gateway-dec.adoc
@@ -98,10 +98,7 @@ See <<ref_dec_obx4>> for further information.
 
 |OBX-5
 |Observation Value
-|pm:PatientContextState
-/pm:CoreData
-/pm:Height
-/@MeasuredValue
+|pm:PatientContextState+++<wbr/>+++/pm:CoreData+++<wbr/>+++/pm:Height+++<wbr/>+++/@MeasuredValue
 |Note that the decimal number needs to be formatted according to the HL7 numeric value formatting rules.
 
 |OBX-6
@@ -111,33 +108,21 @@ See <<ref_dec_obx4>> for further information.
 
 |OBX-6/CWE-1
 |Identifier
-|pm:PatientContextState
-/pm:CoreData
-/pm:Height
-/pm:MeasurementUnit
-/@Code
+|pm:PatientContextState+++<wbr/>+++/pm:CoreData+++<wbr/>+++/pm:Height+++<wbr/>+++/pm:MeasurementUnit+++<wbr/>+++/@Code
 |
 
 |OBX-6/CWE-2
 |Text
 |If @Code is an MDC code, this field contains the RefId of the MDC code.
 
-In all other cases, the field is set to the pm:PatientContextState
-/pm:CoreData
-/pm:Height
-/pm:MeasurementUnit
-/@SymbolicCodeName.
+In all other cases, the field is set to the pm:PatientContextState+++<wbr/>+++/pm:CoreData+++<wbr/>+++/pm:Height+++<wbr/>+++/pm:MeasurementUnit+++<wbr/>+++/@SymbolicCodeName.
 |Note that MDC is the default coding system if no coding system is specified.
 
 |OBX-6/CWE-3
 |Name of Coding System
 |*"MDC"* if no other coding system is specified.
 
-In all other cases, the field is set to pm:PatientContextState
-/pm:CoreData
-/pm:Height
-/pm:MeasurementUnit
-/@CodingSystem.
+In all other cases, the field is set to pm:PatientContextState+++<wbr/>+++/pm:CoreData+++<wbr/>+++/pm:Height+++<wbr/>+++/pm:MeasurementUnit+++<wbr/>+++/@CodingSystem.
 |Note that MDC is the default coding system if no coding system is specified.
 
 |OBX-11
@@ -149,8 +134,7 @@ When there are further updates of the height value after the association of the 
 
 |OBX-14
 |Date/Time of the Observation
-|pm:PatientContextState
-/@BindingStartTime
+|pm:PatientContextState+++<wbr/>+++/@BindingStartTime
 |Note that the HL7 date & time format differs from the xsd date/time formats and requires a mapping accordingly (see also <<ref_expl_dt_mapping>>).
 
 |===
@@ -195,10 +179,7 @@ See <<ref_dec_obx4>> for further information.
 
 |OBX-5
 |Observation Value
-|pm:PatientContextState
-/pm:CoreData
-/pm:Weight
-/@MeasuredValue
+|pm:PatientContextState+++<wbr/>+++/pm:CoreData+++<wbr/>+++/pm:Weight+++<wbr/>+++/@MeasuredValue
 |Note that the decimal number needs to be formatted according to the HL7 numeric value formatting rules.
 
 |OBX-6
@@ -208,10 +189,7 @@ See <<ref_dec_obx4>> for further information.
 
 |OBX-6/CWE-1
 |Identifier
-|pm:PatientContextState
-/pm:CoreData
-/pm:Weight
-/pm:MeasurementUnit
+|pm:PatientContextState+++<wbr/>+++/pm:CoreData+++<wbr/>+++/pm:Weight+++<wbr/>+++/pm:MeasurementUnit
 /@Code
 |
 
@@ -219,10 +197,7 @@ See <<ref_dec_obx4>> for further information.
 |Text
 |If @Code is an MDC code, this field contains the RefId of the MDC code.
 
-In all other cases, the field is set to the pm:PatientContextState
-/pm:CoreData
-/pm:Weight
-/pm:MeasurementUnit
+In all other cases, the field is set to the pm:PatientContextState+++<wbr/>+++/pm:CoreData+++<wbr/>+++/pm:Weight+++<wbr/>+++/pm:MeasurementUnit
 /@SymbolicCodeName.
 |Note that MDC is the default coding system if no coding system is specified.
 
@@ -230,10 +205,7 @@ In all other cases, the field is set to the pm:PatientContextState
 |Name of Coding System
 |*"MDC"* if no other coding system is specified.
 
-In all other cases, the field is set to pm:PatientContextState
-/pm:CoreData
-/pm:Weight
-/pm:MeasurementUnit
+In all other cases, the field is set to pm:PatientContextState+++<wbr/>+++/pm:CoreData+++<wbr/>+++/pm:Weight+++<wbr/>+++/pm:MeasurementUnit
 /@CodingSystem.
 |Note that MDC is the default coding system if no coding system is specified.
 
@@ -346,20 +318,17 @@ Only metrics that fulfil certain criteria are exported by the <<actor_somds_dec_
 
 |OBR-7/DTM-1
 |Date/Time
-|pm:EnumStringMetricState
-/pm:MetricValue
+|pm:EnumStringMetricState+++<wbr/>+++/pm:MetricValue
 /@DeterminationTime
 
-pm:NumericMetricState
-/pm:MetricValue
+pm:NumericMetricState+++<wbr/>+++/pm:MetricValue
 /@DeterminationTime
 
-pm:StringMetricState
-/pm:MetricValue
+pm:StringMetricState+++<wbr/>+++/pm:MetricValue
 /@DeterminationTime
-|If *pm:AbstractMetricDescriptor /@MetricAvailability* is set to "*Cont*", the field is set to the *@DeterminationTime* of the continuously measured metrics to be exported in the same HL7 message with the same *@DeterminationTime*. Episodic metrics are exported in the same HL7 message, when their *@DeterminationTime* is equal or older than the *@DeterminationTime* of the continuously measured metrics.
+|If *pm:AbstractMetricDescriptor+++<wbr/>+++/@MetricAvailability* is set to "*Cont*", the field is set to the *@DeterminationTime* of the continuously measured metrics to be exported in the same HL7 message with the same *@DeterminationTime*. Episodic metrics are exported in the same HL7 message, when their *@DeterminationTime* is equal or older than the *@DeterminationTime* of the continuously measured metrics.
 
-If *pm:AbstractMetricDescriptor /@MetricAvailability* is set to "*Intr*" and if there are no continuously measured metrics to be exported, the field is set to the oldest *@DeterminationTime* of the episodic metrics to be exported in the same HL7 message.
+If *pm:AbstractMetricDescriptor+++<wbr/>+++/@MetricAvailability* is set to "*Intr*" and if there are no continuously measured metrics to be exported, the field is set to the oldest *@DeterminationTime* of the episodic metrics to be exported in the same HL7 message.
 
 Note that the HL7 date and time format differs from the XML Schema date/time formats and requires a mapping accordingly (see also <<ref_expl_dt_mapping>>).
 
@@ -399,8 +368,7 @@ NOTE: The SDC operator context is only valid when the *pm:OperatorContextState/@
 
 |OBR-10/XCN-1
 |ID Number
-|pm:OperatorContextState
-/pm:Identification
+|pm:OperatorContextState+++<wbr/>+++/pm:Identification
 /@Extension
 |The @Extension attribute contains the unique operator identifier.
 
@@ -408,8 +376,7 @@ NOTE: The SDC operator context is only valid when the *pm:OperatorContextState/@
 
 |OBR-10/XCN-2
 |Family Name
-|pm:OperatorContextState
-/pm:OperatorDetails
+|pm:OperatorContextState+++<wbr/>+++/pm:OperatorDetails
 |HL7 data type *FN*
 
 |OBR-10/XCN-2.1
@@ -419,16 +386,12 @@ NOTE: The SDC operator context is only valid when the *pm:OperatorContextState/@
 
 |OBR-10/XCN-3
 |Given Name
-|pm:OperatorContextState
-/pm:OperatorDetails
-/pm:Givenname
+|pm:OperatorContextState+++<wbr/>+++/pm:OperatorDetails+++<wbr/>+++/pm:Givenname
 |
 
 |OBR-10/XCN-4
 |Second and Further Given Names or Initials
-|pm:OperatorContextState
-/pm:OperatorDetails
-/pm:Middlename
+|pm:OperatorContextState+++<wbr/>+++/pm:OperatorDetails+++<wbr/>+++/pm:Middlename
 |
 
 |OBR-10/XCN-6
@@ -618,14 +581,14 @@ If a private *MDC* code is used for the coding of the SDC coded element value in
 |Text
 |If *@Code* is an MDC code, this field contains the RefId of the MDC code.
 
-In all other cases, the field is set to the pm:EnumStringMetricDescriptor /pm:AllowedValue /pm:Type /@SymbolicCodeName.
+In all other cases, the field is set to the pm:EnumStringMetricDescriptor+++<wbr/>+++/pm:AllowedValue+++<wbr/>+++/pm:Type+++<wbr/>+++/@SymbolicCodeName.
 | Note that MDC is the default coding system if no coding system is specified.
 
 |OBX-5/CWE-3
 |Name of Coding System
 |*"MDC"* if no other coding system is specified.
 
-In all other cases, the field is set to pm:EnumStringMetricDescriptor /pm:AllowedValue /pm:Type /@CodingSystem.
+In all other cases, the field is set to pm:EnumStringMetricDescriptor+++<wbr/>+++/pm:AllowedValue+++<wbr/>+++/pm:Type+++<wbr/>+++/@CodingSystem.
 
 |Note that MDC is the default coding system if no coding system is specified.
 
@@ -669,14 +632,14 @@ If a private *MDC* code is used for the coding of the SDC measurement unit of a 
 |Text
 |If *@Code* is an MDC code, this field contains the RefId of the MDC code.
 
-In all other cases, the field is set to the pm:NumericMetricDescriptor /pm:Unit /@SymbolicCodeName.
+In all other cases, the field is set to the pm:NumericMetricDescriptor+++<wbr/>+++/pm:Unit+++<wbr/>+++/@SymbolicCodeName.
 | Note that MDC is the default coding system if no coding system is specified.
 
 |OBX-6/CWE-3
 |Name of Coding System
 |*"MDC"* if no other coding system is specified.
 
-In all other cases, the field is set to pm:NumericMetricDescriptor /pm:Unit /@CodingSystem.
+In all other cases, the field is set to pm:NumericMetricDescriptor+++<wbr/>+++/pm:Unit+++<wbr/>+++/@CodingSystem.
 
 |Note that MDC is the default coding system if no coding system is specified.
 

--- a/SDPi_Supplement/asciidoc/volume2/gateways/tf2-ch-b-gateway-msh-mapping.adoc
+++ b/SDPi_Supplement/asciidoc/volume2/gateways/tf2-ch-b-gateway-msh-mapping.adoc
@@ -33,8 +33,7 @@ NOTE: <<ref_tbl_msh11_mapping>> defines the mapping of the SDC MDS information t
 
 |MSH-11/PT-1
 |Processing ID
-|pm:MdsState
-/@OperatingMode
+|pm:MdsState+++<wbr/>+++/@OperatingMode
 |Note that the HL7 Processing ID value set (HL7 table 0103) differs from the SDC pm:MdsOperatingMode value set and requires a mapping accordingly (see also <<ref_tbl_mdsopmode_mapping>>).
 
 |===

--- a/SDPi_Supplement/asciidoc/volume2/gateways/tf2-ch-b-gateway-obx18-mapping.adoc
+++ b/SDPi_Supplement/asciidoc/volume2/gateways/tf2-ch-b-gateway-obx18-mapping.adoc
@@ -43,26 +43,17 @@ NOTE: <<ref_tbl_dec_obx18_vmd_mapping>> defines the mapping of the <<acronym_mdi
 |OBX-18/EI-1
 |Entity Identifier
 |pm:Mds
-/pm:MetaData
-/pm:Udi
-/pm:DeviceIdentifier
+/pm:MetaData+++<wbr/>+++/pm:Udi+++<wbr/>+++/pm:DeviceIdentifier
 |
 
 |OBX-18/EI-2
 |Namespace ID
-|pm:Mds
-/pm:MetaData
-/pm:Udi
-/pm:Issuer
-/@Root
+|pm:Mds+++<wbr/>+++/pm:MetaData+++<wbr/>+++/pm:Udi+++<wbr/>+++/pm:Issuer+++<wbr/>+++/@Root
 |
 
 |OBX-18/EI-3
 |Universal ID
-|pm:Mds
-/pm:MetaData
-/pm:Udi
-/pm:DeviceIdentifier
+|pm:Mds+++<wbr/>+++/pm:MetaData+++<wbr/>+++/pm:Udi+++<wbr/>+++/pm:DeviceIdentifier
 |
 
 |OBX-18/EI-4

--- a/SDPi_Supplement/asciidoc/volume2/gateways/tf2-ch-b-gateway-obx3-mapping.adoc
+++ b/SDPi_Supplement/asciidoc/volume2/gateways/tf2-ch-b-gateway-obx3-mapping.adoc
@@ -24,23 +24,21 @@ If a private *MDC* code is used for the coding of the SDC containment tree eleme
 
 |OBX-3/CWE-1
 |Identifier
-|pm:Mds
-/pm:Type
-/@Code
+|pm:Mds+++<wbr/>+++/pm:Type+++<wbr/>+++/@Code
 |
 
 |OBX-3/CWE-2
 |Text
 |If *@Code* is an MDC code, this field contains the RefId of the MDC code.
 
-In all other cases, the field is set to the pm:Mds /pm:Type /@SymbolicCodeName.
+In all other cases, the field is set to the pm:Mds+++<wbr/>+++/pm:Type+++<wbr/>+++/@SymbolicCodeName.
 | Note that MDC is the default coding system if no coding system is specified.
 
 |OBX-3/CWE-3
 |Name of Coding System
 |*"MDC"* if no other coding system is specified.
 
-In all other cases, the field is set to pm:Mds /pm:Type /@CodingSystem.
+In all other cases, the field is set to pm:Mds+++<wbr/>+++/pm:Type+++<wbr/>+++/@CodingSystem.
 
 |Note that MDC is the default coding system if no coding system is specified.
 
@@ -53,23 +51,21 @@ In all other cases, the field is set to pm:Mds /pm:Type /@CodingSystem.
 
 |OBX-3/CWE-1
 |Identifier
-|pm:Vmd
-/pm:Type
-/@Code
+|pm:Vmd+++<wbr/>+++/pm:Type+++<wbr/>+++/@Code
 |
 
 |OBX-3/CWE-2
 |Text
 |If *@Code* is an MDC code, this field contains the RefId of the MDC code.
 
-In all other cases, the field is set to the pm:Vmd /pm:Type /@SymbolicCodeName.
+In all other cases, the field is set to the pm:Vmd+++<wbr/>+++/pm:Type+++<wbr/>+++/@SymbolicCodeName.
 | Note that MDC is the default coding system if no coding system is specified.
 
 |OBX-3/CWE-3
 |Name of Coding System
 |*"MDC"* if no other coding system is specified.
 
-In all other cases, the field is set to pm:Vmd /pm:Type /@CodingSystem.
+In all other cases, the field is set to pm:Vmd+++<wbr/>+++/pm:Type+++<wbr/>+++/@CodingSystem.
 
 |Note that MDC is the default coding system if no coding system is specified.
 
@@ -82,16 +78,14 @@ In all other cases, the field is set to pm:Vmd /pm:Type /@CodingSystem.
 
 |OBX-3/CWE-1
 |Identifier
-|pm:Channel
-/pm:Type
-/@Code
+|pm:Channel+++<wbr/>+++/pm:Type+++<wbr/>+++/@Code
 |
 
 |OBX-3/CWE-2
 |Text
 |If *@Code* is an MDC code, this field contains the RefId of the MDC code.
 
-In all other cases, the field is set to the pm:Channel /pm:Type /@SymbolicCodeName.
+In all other cases, the field is set to the pm:Channel+++<wbr/>+++/pm:Type+++<wbr/>+++/@SymbolicCodeName.
 | Note that MDC is the default coding system if no coding system is specified.
 
 |OBX-3/CWE-3
@@ -111,17 +105,11 @@ In all other cases, the field is set to pm:Channel /pm:Type /@CodingSystem.
 
 |OBX-3/CWE-1
 |Identifier
-|pm:NumericMetricDescriptor
-/pm:Type
-/@Code
+|pm:NumericMetricDescriptor+++<wbr/>+++/pm:Type+++<wbr/>+++/@Code
 
-pm:StringMetricDescriptor
-/pm:Type
-/@Code
+pm:StringMetricDescriptor+++<wbr/>+++/pm:Type+++<wbr/>+++/@Code
 
-pm:EnumStringMetricDescriptor
-/pm:Type
-/@Code
+pm:EnumStringMetricDescriptor+++<wbr/>+++/pm:Type+++<wbr/>+++/@Code
 |
 
 |OBX-3/CWE-2

--- a/SDPi_Supplement/asciidoc/volume2/gateways/tf2-ch-b-gateway-pid-mapping.adoc
+++ b/SDPi_Supplement/asciidoc/volume2/gateways/tf2-ch-b-gateway-pid-mapping.adoc
@@ -40,17 +40,14 @@ NOTE: If the <<acronym_mdib>> patient identification element *pm:PatientContextS
 
 |PID-3/CX-1
 |ID Number
-|pm:PatientContextState
-/pm:Identification
-/@Extension
+|pm:PatientContextState+++<wbr/>+++/pm:Identification+++<wbr/>+++/@Extension
 |The @Extension attribute contains the unique patient identifer.
 
 *Note that the field may contain a null value indicating that the identifier is missing.*
 
 |PID-3/CX-4
 |Assigning Authority
-|pm:PatientContextState
-/pm:Identification
+|pm:PatientContextState+++<wbr/>+++/pm:Identification
 | HL7 data type *HD*
 
 |PID-3/CX-4.1
@@ -62,10 +59,7 @@ NOTE: If the <<acronym_mdib>> patient identification element *pm:PatientContextS
 
 |PID-3/CX-5
 |Identifier Type Code
-|pm:PatientContextState
-/pm:Identification
-/pm:Type
-/@Code
+|pm:PatientContextState+++<wbr/>+++/pm:Identification+++<wbr/>+++/pm:Type+++<wbr/>+++/@Code
 |The type of the patient identifier set in the @Code attribute is set to a value from HL7 V2 table 0203. The @CodingSystem is set to `urn:oid:2.16.840.1.113883.18.108`.
 
 |===
@@ -114,8 +108,7 @@ NOTE: <<ref_tbl_pid5_mapping>> defines the mapping of the SDC patient name infor
 
 |PID-5/XPN-1
 |Family Name
-|pm:PatientContextState
-/pm:CoreData
+|pm:PatientContextState+++<wbr/>+++/pm:CoreData
 |HL7 data type *FN*
 
 |PID-5/XPN-1.1
@@ -125,29 +118,22 @@ NOTE: <<ref_tbl_pid5_mapping>> defines the mapping of the SDC patient name infor
 
 |PID-5/XPN-2
 |Given Name
-|pm:PatientContextState
-/pm:CoreData
-/pm:Givenname
+|pm:PatientContextState+++<wbr/>+++/pm:CoreData+++<wbr/>+++/pm:Givenname
 |
 
 |PID-5/XPN-3
 |Second and Further Given Names or Initials
-|pm:PatientContextState
-/pm:CoreData
-/pm:Middlename
+|pm:PatientContextState+++<wbr/>+++/pm:CoreData+++<wbr/>+++/pm:Middlename
 |
 
 |PID-5/XPN-5
 |Prefix (e.g. DR)
-|pm:PatientContextState
-/pm:CoreData
-/pm:Title
+|pm:PatientContextState+++<wbr/>+++/pm:CoreData+++<wbr/>+++/pm:Title
 |
 
 |PID-5/XPN-7
 |Name Type Code
-|pm:PatientContextState
-/pm:CoreData
+|pm:PatientContextState+++<wbr/>+++/pm:CoreData
 |This field shall be set to "L" when a patient name is available, or "U" when the patient name is not set.
 
 Please refer also to the corresponding section in the <<ref_ihe_pcd_tf_2_2019>>.
@@ -174,8 +160,7 @@ NOTE: <<ref_tbl_pid6_mapping>> defines the mapping of the SDC patient name infor
 
 |PID-6/XPN-1
 |Family Name
-|pm:PatientContextState
-/pm:CoreData
+|pm:PatientContextState+++<wbr/>+++/pm:CoreData
 |HL7 data type *FN*
 
 |PID-6/XPN-1.1
@@ -205,9 +190,7 @@ NOTE: <<ref_tbl_pid7_mapping>> defines the mapping of the SDC patient's date of 
 
 |PID-6/DTM-1
 |Date/Time
-|pm:PatientContextState
-/pm:CoreData
-/pm:DateOfBirth
+|pm:PatientContextState+++<wbr/>+++/pm:CoreData+++<wbr/>+++/pm:DateOfBirth
 |Note that the HL7 date & time format differs from the xsd date/time formats and requires a mapping accordingly (see also <<ref_expl_dt_mapping>>).
 
 |===
@@ -272,9 +255,7 @@ The sex and gender of a patient (or a newborn) cannot exactly be mapped from ISO
 
 |PID-8/IS-1
 |Administrative Sex
-|pm:PatientContextState
-/pm:CoreData
-/pm:Sex
+|pm:PatientContextState+++<wbr/>+++/pm:CoreData+++<wbr/>+++/pm:Sex
 |Note that the HL7 Administrative Sex value set (HL7 table 0001) differs from the SDC pm:Sex value set and requires a mapping accordingly (see also <<ref_tbl_sex_mapping>>).
 
 |===
@@ -328,60 +309,43 @@ NOTE: <<ref_tbl_pid10_mapping>> defines the mapping of the SDC patient's race in
 
 |PID-10/CWE-1
 |Identifier
-|pm:PatientContextState
-/pm:CoreData
-/pm:Race
+|pm:PatientContextState+++<wbr/>+++/pm:CoreData+++<wbr/>+++/pm:Race
 /@Code
 |
 
 |PID-10/CWE-2
 |Text
-|pm:PatientContextState
-/pm:CoreData
-/pm:Race
+|pm:PatientContextState+++<wbr/>+++/pm:CoreData+++<wbr/>+++/pm:Race
 /@SymbolicCodeName
 |
 
 |PID-10/CWE-3
 |Name of Coding System
-|pm:PatientContextState
-/pm:CoreData
-/pm:Race
+|pm:PatientContextState+++<wbr/>+++/pm:CoreData+++<wbr/>+++/pm:Race
 /@CodingSystem
 |
 
 |PID-10/CWE-4
 |Alternate Identifier
-|pm:PatientContextState
-/pm:CoreData
-/pm:Race
-/pm:Translation
+|pm:PatientContextState+++<wbr/>+++/pm:CoreData+++<wbr/>+++/pm:Race+++<wbr/>+++/pm:Translation
 /@Code
 |Note that only the first entry of the *pm:Translation* element list shall be mapped.
 
 |PID-10/CWE-6
 |Name of Alternate Coding System
-|pm:PatientContextState
-/pm:CoreData
-/pm:Race
-/pm:Translation
+|pm:PatientContextState+++<wbr/>+++/pm:CoreData+++<wbr/>+++/pm:Race+++<wbr/>+++/pm:Translation
 /@CodingSystem
 |Note that only the first entry of the *pm:Translation* element list shall be mapped.
 
 |PID-10/CWE-7
 |Coding System Version ID
-|pm:PatientContextState
-/pm:CoreData
-/pm:Race
+|pm:PatientContextState+++<wbr/>+++/pm:CoreData+++<wbr/>+++/pm:Race
 /@CodingSystemVersion
 |
 
 |PID-10/CWE-8
 |Alternate Coding System Version ID
-|pm:PatientContextState
-/pm:CoreData
-/pm:Race
-/pm:Translation
+|pm:PatientContextState+++<wbr/>+++/pm:CoreData+++<wbr/>+++/pm:Race+++<wbr/>+++/pm:Translation
 /@CodingSystemVersion
 |Note that only the first entry of the *pm:Translation* element list shall be mapped.
 

--- a/SDPi_Supplement/asciidoc/volume2/gateways/tf2-ch-b-gateway-private-mdc-mapping.adoc
+++ b/SDPi_Supplement/asciidoc/volume2/gateways/tf2-ch-b-gateway-private-mdc-mapping.adoc
@@ -17,8 +17,7 @@ The following example uses the SDC *pm:Type* to demonstrate the mapping of priva
 
 |CWE-1
 |Identifier
-|pm:Type
-/@Code
+|pm:Type+++<wbr/>+++/@Code
 | This attribute contains the private *MDC* code.
 
 |CWE-2
@@ -33,29 +32,22 @@ The following example uses the SDC *pm:Type* to demonstrate the mapping of priva
 
 |CWE-4
 |Alternate Identifier
-|pm:Type
-/pm:Translation
-/@Code
+|pm:Type+++<wbr/>+++/pm:Translation+++<wbr/>+++/@Code
 |This code shall be identical with the *pm:Type/@Code* attribute.
 
 |CWE-6
 |Name of Alternate Coding System
-|pm:Type
-/pm:Translation
-/@CodingSystem
+|pm:Type+++<wbr/>+++/pm:Translation+++<wbr/>+++/@CodingSystem
 |This attribute specifies the vendor-specific or local coding system that has defined the private *MDC* code.
 
 |CWE-7
 |Coding System Version ID
-|pm:Type
-/@CodingSystemVersion
+|pm:Type+++<wbr/>+++/@CodingSystemVersion
 |
 
 |CWE-8
 |Alternate Coding System Version ID
-|pm:Type
-/pm:Translation
-/@CodingSystemVersion
+|pm:Type+++<wbr/>+++/pm:Translation+++<wbr/>+++/@CodingSystemVersion
 |
 
 |===

--- a/SDPi_Supplement/asciidoc/volume2/gateways/tf2-ch-b-gateway-pv1-mapping.adoc
+++ b/SDPi_Supplement/asciidoc/volume2/gateways/tf2-ch-b-gateway-pv1-mapping.adoc
@@ -48,29 +48,22 @@ NOTE: <<ref_tbl_pv13_mapping>> defines the mapping of the SDC patient location i
 
 |PV1-3/PL-1
 |Point of Care
-|pm:LocationContextState
-/pm:LocationDetail
-/@PoC
+|pm:LocationContextState+++<wbr/>+++/pm:LocationDetail+++<wbr/>+++/@PoC
 |Aka. clinical care unit
 
 |PV1-3/PL-2
 |Room
-|pm:LocationContextState
-/pm:LocationDetail
-/@Room
+|pm:LocationContextState+++<wbr/>+++/pm:LocationDetail+++<wbr/>+++/@Room
 |
 
 |PV1-3/PL-3
 |Bed
-|pm:LocationContextState
-/pm:LocationDetail
-/@Bed
+|pm:LocationContextState+++<wbr/>+++/pm:LocationDetail+++<wbr/>+++/@Bed
 |
 
 |PV1-3/PL-4
 |Facility
-|pm:LocationContextState
-/pm:LocationDetail
+|pm:LocationContextState+++<wbr/>+++/pm:LocationDetail
 |HL7 data type *HD*
 
 |PV1-3/PL-4.1
@@ -80,16 +73,12 @@ NOTE: <<ref_tbl_pv13_mapping>> defines the mapping of the SDC patient location i
 
 |PV1-3/PL-7
 |Building
-|pm:LocationContextState
-/pm:LocationDetail
-/@Building
+|pm:LocationContextState+++<wbr/>+++/pm:LocationDetail+++<wbr/>+++/@Building
 |
 
 |PV1-3/PL-8
 |Floor
-|pm:LocationContextState
-/pm:LocationDetail
-/@Floor
+|pm:LocationContextState+++<wbr/>+++/pm:LocationDetail+++<wbr/>+++/@Floor
 |
 
 |===
@@ -120,17 +109,14 @@ NOTE: A visit identifier could be a visit number, an account number, or any othe
 
 |PV1-19/CX-1
 |ID Number
-|pm:PatientContextState
-/pm:Identification
-/@Extension
+|pm:PatientContextState+++<wbr/>+++/pm:Identification+++<wbr/>+++/@Extension
 |The @Extension attribute contains the unique visit identifier if available.
 
 *Note that the field may contain a null value indicating that the identifier is missing.*
 
 |PV1-19/CX-4
 |Assigning Authority
-|pm:PatientContextState
-/pm:Identification
+|pm:PatientContextState+++<wbr/>+++/pm:Identification
 | HL7 data type *HD*
 
 |PV1-19/CX-4.1
@@ -142,10 +128,7 @@ NOTE: A visit identifier could be a visit number, an account number, or any othe
 
 |PV1-19/CX-5
 |Identifier Type Code
-|pm:PatientContextState
-/pm:Identification
-/pm:Type
-/@Code
+|pm:PatientContextState+++<wbr/>+++/pm:Identification+++<wbr/>+++/pm:Type+++<wbr/>+++/@Code
 |The type of the patient identifier set in the @Code attribute shall be set to a value from HL7 V2 table 0203. The @CodingSystem shall be set to *"urn:oid:2.16.840.1.113883.18.108"*.
 
 Valid *"Identifier Type Code"* values for a visit number are, for example, *"VN"* (Visit Number), *"AN"* (Account Number), etc.


### PR DESCRIPTION
PR now includes virtual newlines which are applied only if there is not enough space in a table cell:

`+++<wbr/>+++`

This is an HTML passthrough indicated by three plus symbols and wbr, the corresponding linebreak opportunity: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/wbr
