### PR TITLE
Updated requirements for a valid patient/location context

### DIFF
--- a/SDPi_Supplement/asciidoc/volume2/gateways/tf2-ch-b-gateway-pid-mapping.adoc
+++ b/SDPi_Supplement/asciidoc/volume2/gateways/tf2-ch-b-gateway-pid-mapping.adoc
@@ -5,12 +5,12 @@ The HL7 Patient Identification (PID) segment requires a mapping from the <<acron
 .R8102
 [sdpi_requirement#r8102,sdpi_req_level=shall,sdpi_max_occurrence=2]
 ****
-The SDC patient context information shall only be mapped to the corresponding fields in the HL7 PID segment when the requirements as defined in <<ref_ieee_11073_10700_2022>> are fulfilled.
+The SDC patient context information shall only be mapped to the corresponding fields in the HL7 PID segment when the requirements for a valid SDC patient context as defined in <<ref_ieee_11073_10700_2022>> are fulfilled.
 
 .Notes
 [%collapsible]
 ====
-NOTE: This affects, e.g. inferred patient ensemble context, associated patient context and others.
+NOTE: For a valid *pm:PatientContextState*, the *pm:AbstractContextState/@ContextAssociation* attribute is set to *"Assoc"* and the *pm:AbstractContextState/pm:Validator* is set to a valid validator. A corresponding inferred patient ensemble context is not required for the <<actor_somds_dec_gateway>> / <<actor_somds_acm_gateway>>.
 
 NOTE: If the SDC patient context information is not intended to be used for the mapping, please refer to the <<ref_ihe_pcd_tf_2_2019>> on how to populate the fields of the PID segment in this case.
 ====

--- a/SDPi_Supplement/asciidoc/volume2/gateways/tf2-ch-b-gateway-pid-mapping.adoc
+++ b/SDPi_Supplement/asciidoc/volume2/gateways/tf2-ch-b-gateway-pid-mapping.adoc
@@ -393,7 +393,13 @@ NOTE: <<ref_tbl_pid10_mapping>> defines the mapping of the SDC patient's race in
 ****
 A <<actor_somds_dec_gateway>> / <<actor_somds_acm_gateway>> shall set the PID-31 field to an indicator whether the patient's identity is known.
 
-The field value is determined from the presence of a patient-inferred ensemble context (*pm:EnsembleContextDescriptor/pm:Type/@Code = MDC_IDT_ENSEMBLE_PATIENT_INFERRED*) with an associated context association state (*pm:EnsembleContextState/@ContextAssociation = Assoc*). In this case, the value is set to "N".
+.Notes
+[%collapsible]
+====
+NOTE: For a valid *pm:PatientContextState*, the *pm:AbstractContextState/@ContextAssociation* attribute is set to *"Assoc"* and the *pm:AbstractContextState/pm:Validator* is set to a valid validator. In this case, the value is set to "N".
 
-In all other cases, the value is set to "Y".
+NOTE: In all other cases, the value is set to "Y".
+
+NOTE: A corresponding inferred patient ensemble context is not required for the <<actor_somds_dec_gateway>> / <<actor_somds_acm_gateway>> in order to determine a valid *pm:PatientContextState*.
+====
 ****

--- a/SDPi_Supplement/asciidoc/volume2/gateways/tf2-ch-b-gateway-pv1-mapping.adoc
+++ b/SDPi_Supplement/asciidoc/volume2/gateways/tf2-ch-b-gateway-pv1-mapping.adoc
@@ -6,9 +6,15 @@ The HL7 Patient Visit (PV1) segment requires a mapping from the SDC patient and 
 .R8111
 [sdpi_requirement#r8111,sdpi_req_level=shall,sdpi_max_occurrence=2]
 ****
-The SDC patient and location context information shall only be mapped to the corresponding fields in the HL7 PV1 segment when the requirements (e.g. inferred patient and/or location ensemble context, associated patient and/or location context, etc.) as defined in the <<ref_ieee_11073_10700_2022>> are fulfilled.
+The SDC patient and location context information shall only be mapped to the corresponding fields in the HL7 PV1 segment when the requirements for a valid SDC patient and location context as defined in the <<ref_ieee_11073_10700_2022>> are fulfilled.
 
-If the SDC patient and/or location context information is not be used for the mapping, please refer to the <<ref_ihe_pcd_tf_2_2019>> on how to populate the fields of the PV1 segment in this case.
+.Notes
+[%collapsible]
+====
+NOTE: For a valid *pm:PatientContextState* or *pm:LocationContextSate*, the *pm:AbstractContextState/@ContextAssociation* attribute is set to *"Assoc"* and the *pm:AbstractContextState/pm:Validator* is set to a valid validator. A corresponding inferred patient or location ensemble context is not required for the <<actor_somds_dec_gateway>> / <<actor_somds_acm_gateway>>.
+
+NOTE: If the SDC patient and/or location context information is not be used for the mapping, please refer to the <<ref_ihe_pcd_tf_2_2019>> on how to populate the fields of the PV1 segment in this case.
+====
 ****
 
 ====== PV1-2 Patient Class


### PR DESCRIPTION
Updated requirements for a valid patient/location context to be used in the HL7 data export.

Rewording of R8102 & R8111.